### PR TITLE
35 backend api

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -97,6 +97,8 @@ dependencies = [
  "anyhow",
  "axum",
  "axum-cookie",
+ "serde",
+ "serde_json",
  "tokio",
 ]
 

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -58,6 +58,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-cookie"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95c4febbfae491fa744b849c66530d4eb71b9cce1ee39ea080a44065aa3d0769"
+dependencies = [
+ "axum-core",
+ "cookie-rs",
+ "http",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "axum-core"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +96,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
+ "axum-cookie",
  "tokio",
 ]
 
@@ -112,6 +126,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cookie-rs"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ee006414d709940b650c419ab49a32b0c5e3187c2930c9fda422ffc6c590b5"
 
 [[package]]
 name = "fnv"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -7,4 +7,6 @@ edition = "2021"
 anyhow = "1.0.95"
 axum = "0.8.1"
 axum-cookie = "0.1.1"
+serde = { version = "1.0.217", features = ["derive"] }
+serde_json = "1.0.138"
 tokio = { version = "1.43.0", features = ["rt-multi-thread", "macros"] }

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.95"
 axum = "0.8.1"
+axum-cookie = "0.1.1"
 tokio = { version = "1.43.0", features = ["rt-multi-thread", "macros"] }

--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -1,4 +1,4 @@
-use axum::http::StatusCode;
+use axum::http::{Request, StatusCode};
 use axum::response::IntoResponse;
 use axum::routing::post;
 use axum::Router;
@@ -18,4 +18,17 @@ async fn dev_auth(cookie: CookieManager) -> Result<impl IntoResponse, StatusCode
     cookie.add(("token", DEV_TOKEN).into());
 
     Ok(StatusCode::OK)
+}
+
+pub async fn auth_middleware<B>(
+    cookie: CookieManager,
+    req: Request<B>,
+) -> Result<Request<B>, StatusCode> {
+    let token = cookie.get("token").ok_or(StatusCode::UNAUTHORIZED)?;
+
+    if token.value() == DEV_TOKEN {
+        return Ok(req);
+    }
+
+    Err(StatusCode::UNAUTHORIZED)
 }

--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -1,0 +1,21 @@
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::routing::post;
+use axum::Router;
+use axum_cookie::CookieManager;
+
+pub const DEV_TOKEN: &str = "11dc7bac0042b71d690a29b2c2787ccb89f9014471902b5667daff7c9b407c9c";
+
+pub fn get_nest() -> Router {
+    Router::new().route("/dev", post(dev_auth))
+}
+
+async fn dev_auth(cookie: CookieManager) -> Result<impl IntoResponse, StatusCode> {
+    if !cfg!(debug_assertions) {
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    cookie.add(("token", DEV_TOKEN).into());
+
+    Ok(StatusCode::OK)
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,13 +1,22 @@
 use anyhow::Context;
+use axum::middleware::map_request;
 use axum::Router;
 use axum_cookie::CookieLayer;
 
 mod auth;
+mod profile;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    let without_auth = Router::new().nest("/auth", auth::get_nest());
+
+    let with_auth = Router::new()
+        .nest("/profile", profile::get_nest())
+        .layer(map_request(auth::auth_middleware));
+
     let router = Router::new()
-        .nest("/auth", auth::get_nest())
+        .merge(without_auth)
+        .merge(with_auth)
         .layer(CookieLayer::strict());
 
     let listener = tokio::net::TcpListener::bind("0.0.0.0:80")

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,9 +1,14 @@
 use anyhow::Context;
 use axum::Router;
+use axum_cookie::CookieLayer;
+
+mod auth;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let router = Router::new();
+    let router = Router::new()
+        .nest("/auth", auth::get_nest())
+        .layer(CookieLayer::strict());
 
     let listener = tokio::net::TcpListener::bind("0.0.0.0:80")
         .await

--- a/backend/src/profile.rs
+++ b/backend/src/profile.rs
@@ -1,0 +1,29 @@
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::routing::get;
+use axum::{Json, Router};
+
+pub fn get_nest() -> Router {
+    Router::new()
+        .route("/", get(get_profile))
+        .route("/username", get(get_profile_username))
+}
+
+async fn get_profile() -> Result<impl IntoResponse, StatusCode> {
+    let mock_data = serde_json::json!({
+        "username": "boris2001",
+        "iconUrl": "https://avatars.githubusercontent.com/u/114882188?v=4",
+        "type": "Full",
+        "addressAmount": 12
+    });
+
+    Ok(Json(mock_data.to_string()))
+}
+
+async fn get_profile_username() -> Result<impl IntoResponse, StatusCode> {
+    let mock_data = serde_json::json!({
+        "username": "boris2001"
+    });
+
+    Ok(Json(mock_data.to_string()))
+}

--- a/docker/Caddyfile.dev
+++ b/docker/Caddyfile.dev
@@ -1,8 +1,4 @@
-{
-	local_certs
-}
-
-localhost {
+http://localhost {
 	handle_path /api/* {
 	    uri strip_prefix /api
 		reverse_proxy api

--- a/docs/api.md
+++ b/docs/api.md
@@ -62,7 +62,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 ...
 {
-  "nickname": "boris2001",  // string
+  "username": "boris2001",  // string
   "iconUrl": "https://...", // string
   "type": "Full",           // "Full"
   "addressAmount": 12       // unsigned number
@@ -86,6 +86,6 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 ...
 {
-  "nickname": "boris2001",  // string
+  "username": "boris2001",  // string
 }
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,18 +6,18 @@ Api uses **http** as proto and **json** as content type
 
 Authorization with github and dev for test
 
-## `POST` `/signin` _in dev_
+## `POST` `/auth` _in dev_
 
 _Description in progress..._
 
-## `POST` `/signin/dev` _in dev_
+## `POST` `/auth/dev` _in dev_
 
 Dev signin for test profile features avaliable only at debug build
 
 ### request
 
 ```text
-POST /signin/dev HTTP/1.1
+POST /auth/dev HTTP/1.1
 ...
 ```
 


### PR DESCRIPTION
# Changes
- update backend api docs
- added `/auth/dev` endpoint
- added `/profile` and `/profile/username` endpoints
- added auth middleware

for now all of this use mock data and one const session token